### PR TITLE
TSV形式のクリップボードコピー機能

### DIFF
--- a/src/main/java/controllers/CrawlHelper.java
+++ b/src/main/java/controllers/CrawlHelper.java
@@ -18,6 +18,7 @@ import models.json.CrawledData;
 import utils.CrawlingUtils;
 import utils.DialogUtils;
 import utils.JsonUtils;
+import utils.TsvExporter;
 import views.logtable.LogTable;
 import views.logtable.LogTableModel;
 
@@ -102,6 +103,11 @@ public class CrawlHelper {
   public void setLogEntriesColor(final ColorType colorType, final List<LogEntry> logEntries) {
     logEntries.forEach(e -> e.setColorType(colorType));
     logTableModel.updateAllRows();
+  }
+
+  public void exportToClipboardWithTsv(final List<LogEntry> logEntries) {
+    final var data = new TsvExporter(extensionHelper).exportString(logEntries);
+    CrawlingUtils.exportToClipBoard(data);
   }
 
   public void exportCrawledData() {

--- a/src/main/java/models/LogEntry.java
+++ b/src/main/java/models/LogEntry.java
@@ -44,7 +44,7 @@ public class LogEntry {
       final IRequestInfo requestInfo, final IResponseInfo responseInfo) {
     this.number = number;
     this.requestName = "";
-    this.url = requestInfo.getUrl().toString();
+    this.url = CrawlingUtils.createUrlStringWithQuery(requestInfo.getUrl());
     this.method = requestInfo.getMethod();
     this.statusCode = responseInfo.getStatusCode();
     this.mime = responseInfo.getStatedMimeType();

--- a/src/main/java/utils/CrawlingUtils.java
+++ b/src/main/java/utils/CrawlingUtils.java
@@ -23,9 +23,28 @@ public class CrawlingUtils {
     return matcher.find() ? matcher.group(1) : "";
   }
 
+  private static boolean hasDefaultUrlPort(final URL url) {
+    final int port = url.getPort();
+    final var protocol = url.getProtocol();
+    return port == -1
+        || ("https".equals(protocol) && port == 443)
+        || ("http".equals(protocol) && port == 80);
+  }
+
   public static String createUrlString(final URL url) {
-    final int port = url.getPort() == -1 ? url.getDefaultPort() : url.getPort();
-    return String.format("%s://%s:%s%s", url.getProtocol(), url.getHost(), port, url.getPath());
+    if (hasDefaultUrlPort(url)) {
+      return String.format("%s://%s%s", url.getProtocol(), url.getHost(), url.getPath());
+    }
+    return String.format("%s://%s:%s%s",
+        url.getProtocol(), url.getHost(), url.getPort(), url.getPath());
+  }
+
+  public static String createUrlStringWithQuery(final URL url) {
+    if (hasDefaultUrlPort(url)) {
+      return String.format("%s://%s%s", url.getProtocol(), url.getHost(), url.getFile());
+    }
+    return String.format("%s://%s:%s%s",
+        url.getProtocol(), url.getHost(), url.getPort(), url.getFile());
   }
 
   public static void applyDuplicatedRequest(final List<LogEntry> entries,
@@ -98,7 +117,7 @@ public class CrawlingUtils {
     }
   }
 
-  public static void toClipBoard(final String message) {
+  public static void exportToClipBoard(final String message) {
     final var toolkit = Toolkit.getDefaultToolkit();
     final var clipboard = toolkit.getSystemClipboard();
     final var selection = new StringSelection(message);

--- a/src/main/java/utils/TsvExporter.java
+++ b/src/main/java/utils/TsvExporter.java
@@ -1,0 +1,185 @@
+package utils;
+
+import burp.IExtensionHelpers;
+import burp.IParameter;
+import burp.IRequestInfo;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import models.LogEntry;
+
+public class TsvExporter {
+
+  private static final String SEPARATOR_TAB = "\t";
+  private static final String SEPARATOR_LINE = "\n";
+
+  private final IExtensionHelpers helper;
+  private final Map<Byte, String> parameterMap;
+
+  public TsvExporter(final IExtensionHelpers helper) {
+    this.helper = helper;
+    this.parameterMap = createParameterMap();
+  }
+
+  private Map<Byte, String> createParameterMap() {
+    final var map = new HashMap<Byte, String>();
+    map.put(IParameter.PARAM_URL, "URL");
+    map.put(IParameter.PARAM_COOKIE, "Cookie");
+    map.put(IParameter.PARAM_BODY, "Body");
+    map.put(IParameter.PARAM_MULTIPART_ATTR, "Body");
+    map.put(IParameter.PARAM_XML, "XML");
+    map.put(IParameter.PARAM_XML_ATTR, "XML");
+    map.put(IParameter.PARAM_JSON, "JSON");
+    return map;
+  }
+
+  public String exportString(final List<LogEntry> logEntries) {
+    final var builder = new StringBuilder();
+    for (final var logEntry : logEntries) {
+
+      final var requestResponse = logEntry.getRequestResponse();
+      if (requestResponse == null || requestResponse.getRequest().length <= 0) {
+        builder.append(createFirstLine(logEntry));
+        continue;
+      }
+
+      final var requestInfo = helper.analyzeRequest(
+          requestResponse.getHttpService(),
+          requestResponse.getRequest()
+      );
+      builder.append(createFirstLine(logEntry.getRequestName(), requestInfo));
+      builder.append(headersToString(requestInfo, List.of("Cookie:")));
+      builder.append(parametersToString(requestInfo));
+    }
+    return builder.toString();
+  }
+
+  private String createFirstLine(final LogEntry logEntry) {
+    final var requestName = logEntry.getRequestName();
+    final var method = logEntry.getMethod();
+    final var urlStr = logEntry.getUrl();
+    final var item = new TsvItem(requestName, method, urlStr, "-", "-", "-");
+    return itemsToString(List.of(item));
+  }
+
+  private String createFirstLine(final String requestName, final IRequestInfo requestInfo) {
+    final var url = requestInfo.getUrl();
+    final var method = requestInfo.getMethod();
+    final var urlStr = CrawlingUtils.createUrlString(url);
+    final var item = new TsvItem(requestName, method, urlStr, "-", "-", "-");
+    return itemsToString(List.of(item));
+  }
+
+  private String headersToString(final IRequestInfo requestInfo, List<String> ignoreHeaders) {
+    final var items = new LinkedList<TsvItem>();
+    final var paths = requestInfo.getUrl().getPath().split("/");
+    for (int i = 1; i < paths.length; i++) {
+      items.add(new TsvItem("Path", Integer.toString(i), paths[i]));
+    }
+
+    final var headers = requestInfo.getHeaders();
+    final var headersExcludeFirstLine = headers.subList(1, headers.size());
+    final var headerItems = headersExcludeFirstLine.stream()
+        .filter(h -> ignoreHeaders.stream().noneMatch(h::startsWith))
+        .map(h -> h.split(": ", 2))
+        .map(h -> h.length == 2
+            ? new TsvItem("Header", h[0], h[1])
+            : new TsvItem("Header", h[0], ""))
+        .collect(Collectors.toList());
+    items.addAll(headerItems);
+
+    return itemsToString(items);
+  }
+
+  private String parametersToString(final IRequestInfo requestInfo) {
+    final var parameters = requestInfo.getParameters();
+    final var items = parameters.stream()
+        .map(TsvItem::new)
+        .collect(Collectors.toList());
+    return itemsToString(items);
+  }
+
+  private String escape(final String str) {
+    return String.format("\"%s\"", str);
+  }
+
+  private String itemsToString(final List<TsvItem> items) {
+    final var builder = new StringBuilder();
+    for (final var item : items) {
+      builder.append(escape(item.getRequestName()));
+      builder.append(SEPARATOR_TAB);
+      builder.append(escape(item.getMethod()));
+      builder.append(SEPARATOR_TAB);
+      builder.append(escape(item.getUrl()));
+      builder.append(SEPARATOR_TAB);
+      builder.append(escape(item.getType()));
+      builder.append(SEPARATOR_TAB);
+      builder.append(escape(item.getName()));
+      builder.append(SEPARATOR_TAB);
+      builder.append(escape(item.getValue()));
+      builder.append(SEPARATOR_LINE);
+    }
+    return builder.toString();
+  }
+
+  private class TsvItem {
+
+    private final String requestName;
+    private final String method;
+    private final String url;
+    private final String type;
+    private final String name;
+    private final String value;
+
+    public TsvItem(final IParameter parameter) {
+      this(
+          "",
+          "",
+          "",
+          parameterMap.get(parameter.getType()),
+          parameter.getName(),
+          parameter.getValue()
+      );
+    }
+
+    public TsvItem(final String type, final String name, final String value) {
+      this("", "", "", type, name, value);
+    }
+
+    public TsvItem(final String requestName, final String method, final String url,
+        final String type, final String name, final String value) {
+      this.requestName = requestName;
+      this.method = method;
+      this.url = url;
+      this.type = type;
+      this.name = name;
+      this.value = value;
+    }
+
+    public String getRequestName() {
+      return requestName;
+    }
+
+    public String getMethod() {
+      return method;
+    }
+
+    public String getUrl() {
+      return url;
+    }
+
+    public String getType() {
+      return type;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public String getValue() {
+      return value;
+    }
+  }
+}

--- a/src/main/java/views/logtable/LogTablePopupMenu.java
+++ b/src/main/java/views/logtable/LogTablePopupMenu.java
@@ -13,6 +13,12 @@ import models.LogEntry;
 public class LogTablePopupMenu extends JPopupMenu {
 
   public LogTablePopupMenu(final CrawlHelper crawlHelper, final List<LogEntry> logEntries) {
+    final var tsvCopyItem = new JMenuItem("TSVコピー");
+    tsvCopyItem.addActionListener(e -> crawlHelper.exportToClipboardWithTsv(logEntries));
+    tsvCopyItem.setAlignmentX(Component.CENTER_ALIGNMENT);
+    add(tsvCopyItem);
+    addSeparator();
+
     // create color menu items
     Arrays.stream(ColorType.values())
         .map(c -> {

--- a/src/test/java/mocks/DummyDataUtils.java
+++ b/src/test/java/mocks/DummyDataUtils.java
@@ -48,6 +48,10 @@ public class DummyDataUtils {
     return createIHttpRequestResponse(null, null, null);
   }
 
+  public static IHttpRequestResponse createIHttpRequestResponse(final byte[] request) {
+    return createIHttpRequestResponse(request, null, null);
+  }
+
   public static IHttpRequestResponse createIHttpRequestResponse(final byte[] request,
       final byte[] response, final IHttpService service) {
     return new IHttpRequestResponse() {
@@ -114,10 +118,15 @@ public class DummyDataUtils {
 
   public static LogEntry createLogEntry(final int number,
       final IHttpRequestResponse requestResponse) {
+    return createLogEntry(number, "top", "https://example.com", "GET", requestResponse);
+  }
+
+  public static LogEntry createLogEntry(final int number, final String requestName,
+      final String url, final String method, final IHttpRequestResponse requestResponse) {
     final var logEntry = new LogEntry(number);
-    logEntry.setRequestName("top");
-    logEntry.setUrl("https://example.com");
-    logEntry.setMethod("GET");
+    logEntry.setRequestName(requestName);
+    logEntry.setUrl(url);
+    logEntry.setMethod(method);
     logEntry.setStatusCode((short) 200);
     logEntry.setMime("HTML");
     logEntry.setExtension("html");
@@ -132,6 +141,11 @@ public class DummyDataUtils {
 
   public static IRequestInfo createIRequestInfo(final String method, final URL url,
       final List<IParameter> parameters) {
+    return createIRequestInfo(method, url, parameters, null);
+  }
+
+  public static IRequestInfo createIRequestInfo(final String method, final URL url,
+      final List<IParameter> parameters, final List<String> headers) {
     return new IRequestInfo() {
       @Override
       public String getMethod() {
@@ -145,7 +159,7 @@ public class DummyDataUtils {
 
       @Override
       public List<String> getHeaders() {
-        return null;
+        return headers;
       }
 
       @Override
@@ -166,6 +180,11 @@ public class DummyDataUtils {
   }
 
   public static IParameter createIParameter(final byte type, final String name) {
+    return createIParameter(type, name, "");
+  }
+
+  public static IParameter createIParameter(final byte type, final String name,
+      final String value) {
     return new IParameter() {
 
       @Override
@@ -180,7 +199,7 @@ public class DummyDataUtils {
 
       @Override
       public String getValue() {
-        return null;
+        return value;
       }
 
       @Override

--- a/src/test/java/utils/CrawlingUtilsTest.java
+++ b/src/test/java/utils/CrawlingUtilsTest.java
@@ -154,12 +154,27 @@ class CrawlingUtilsTest {
 
   @ParameterizedTest
   @CsvSource({
-      "https://example.com/test, https://example.com:443/test",
+      "https://example.com/test, https://example.com/test",
       "https://example.com:8080/test?a=1&b=2, https://example.com:8080/test",
+      "https://example.com:80/test, https://example.com:80/test",
+      "http://example.com:443/test?/a??=#hash, http://example.com:443/test",
       "http://user:password@172.168.1.56:8088/a/b/c#hash, http://172.168.1.56:8088/a/b/c"
   })
   void testCreateUrlString(final URL url, final String expected) {
     assertEquals(expected, CrawlingUtils.createUrlString(url));
+  }
+
+
+  @ParameterizedTest
+  @CsvSource({
+      "https://example.com/test, https://example.com/test",
+      "https://example.com:8080/test?a=1&b=2, https://example.com:8080/test?a=1&b=2",
+      "https://example.com:80/test, https://example.com:80/test",
+      "http://example.com:443/test?/a??=#hash, http://example.com:443/test?/a??=",
+      "http://user:password@172.168.1.56:8088/a/b/c#hash, http://172.168.1.56:8088/a/b/c"
+  })
+  void testCreateUrlStringWithQuery(final URL url, final String expected) {
+    assertEquals(expected, CrawlingUtils.createUrlStringWithQuery(url));
   }
 
   @ParameterizedTest
@@ -167,8 +182,8 @@ class CrawlingUtilsTest {
       "test",
       "https://example.com:8080/\ttrue\ttrue\nhttps://example.com:8080/test?a=1&b=2\tfalse\ttrue",
   })
-  void testClipBoard(final String message) throws IOException, UnsupportedFlavorException {
-    CrawlingUtils.toClipBoard(message);
+  void testExportToClipBoard(final String message) throws IOException, UnsupportedFlavorException {
+    CrawlingUtils.exportToClipBoard(message);
     final var toolkit = Toolkit.getDefaultToolkit();
     final var clipboard = toolkit.getSystemClipboard();
     final var result = clipboard.getData(DataFlavor.stringFlavor);

--- a/src/test/java/utils/TsvExporterTest.java
+++ b/src/test/java/utils/TsvExporterTest.java
@@ -1,0 +1,82 @@
+package utils;
+
+import static mocks.DummyDataUtils.createIHttpRequestResponse;
+import static mocks.DummyDataUtils.createIParameter;
+import static mocks.DummyDataUtils.createIRequestInfo;
+import static mocks.DummyDataUtils.createLogEntry;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+
+import burp.IExtensionHelpers;
+import burp.IParameter;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class TsvExporterTest {
+
+  private static IExtensionHelpers helpers;
+
+  @BeforeAll
+  static void init() throws MalformedURLException {
+    helpers = Mockito.mock(IExtensionHelpers.class);
+    final var param1 = List.of(
+        createIParameter(IParameter.PARAM_URL, "query1", "1")
+    );
+    final var param2 = List.of(
+        createIParameter(IParameter.PARAM_COOKIE, "cookie1", "aaa"),
+        createIParameter(IParameter.PARAM_COOKIE, "cookie2", "bbb"),
+        createIParameter(IParameter.PARAM_BODY, "body1", "key"),
+        createIParameter(IParameter.PARAM_BODY, "body2", "word")
+    );
+    final var header1 = List.of(
+        "GET /?query1=1 HTTP/1.1",
+        "Host: example.com"
+    );
+    final var header2 = List.of(
+        "POST / HTTP/1.1",
+        "Host: example.com",
+        "Cookie: cookie1=aaa; cookie2=bbb",
+        "Referer: https://example.com/?query1=1",
+        "Content-Length: 20"
+    );
+    final var info1 = createIRequestInfo("GET", new URL("https://example.com/?query1=1"), param1,
+        header1);
+    final var info2 = createIRequestInfo("POST", new URL("https://example.com/"), param2, header2);
+    final var request1 = "1".getBytes(StandardCharsets.UTF_8);
+    final var request2 = "2".getBytes(StandardCharsets.UTF_8);
+    Mockito.when(helpers.analyzeRequest(any(), eq(request1))).thenReturn(info1);
+    Mockito.when(helpers.analyzeRequest(any(), eq(request2))).thenReturn(info2);
+  }
+
+  @Test
+  void testExportToString() {
+    final var request1 = createIHttpRequestResponse("1".getBytes(StandardCharsets.UTF_8));
+    final var request2 = createIHttpRequestResponse("2".getBytes(StandardCharsets.UTF_8));
+    final var logEntries = List.of(
+        createLogEntry(1, "TOP", "https://example.com/?query1=1", "GET", request1),
+        createLogEntry(2, "TOP>ログイン", "https://example.com/", "POST", request2)
+    );
+    final var exporter = new TsvExporter(helpers);
+    final var expectedArray = new String[]{
+        "\"TOP\"\t\"GET\"\t\"https://example.com/\"\t\"-\"\t\"-\"\t\"-\"\n",
+        "\"\"\t\"\"\t\"\"\t\"Header\"\t\"Host\"\t\"example.com\"\n",
+        "\"\"\t\"\"\t\"\"\t\"URL\"\t\"query1\"\t\"1\"\n",
+        "\"TOP>ログイン\"\t\"POST\"\t\"https://example.com/\"\t\"-\"\t\"-\"\t\"-\"\n",
+        "\"\"\t\"\"\t\"\"\t\"Header\"\t\"Host\"\t\"example.com\"\n",
+        "\"\"\t\"\"\t\"\"\t\"Header\"\t\"Referer\"\t\"https://example.com/?query1=1\"\n",
+        "\"\"\t\"\"\t\"\"\t\"Header\"\t\"Content-Length\"\t\"20\"\n",
+        "\"\"\t\"\"\t\"\"\t\"Cookie\"\t\"cookie1\"\t\"aaa\"\n",
+        "\"\"\t\"\"\t\"\"\t\"Cookie\"\t\"cookie2\"\t\"bbb\"\n",
+        "\"\"\t\"\"\t\"\"\t\"Body\"\t\"body1\"\t\"key\"\n",
+        "\"\"\t\"\"\t\"\"\t\"Body\"\t\"body2\"\t\"word\"\n"
+    };
+    final var expected = String.join("", expectedArray);
+    assertEquals(expected, exporter.exportString(logEntries));
+  }
+}


### PR DESCRIPTION
- テーブルのコンテキストメニューに「TSVコピー」を追加。
  - リクエスト名、メソッド、URLおよびヘッダを含む各パラメータをタブ区切りでクリップボードにコピーする。